### PR TITLE
Add parent category filter type, various enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 All notable changes to this project will be documented in this file.
 
 ## [1.1.0] - 2020-11-20
+- added parent category filter type
 - added CategoryModel::getChildCategories()
 - added CategoryModel::hasChildCategories()
 - added CategoryModel annotation
-- fixed imports in CategoryManager
+- moved filter config element dca config to loadDataContainer hook
+- update some imports in CategoryManager
 
 ## [1.0.3] - 2020-08-25
 - fixed save issue if category is multilingual

--- a/src/EventListener/LoadDataContainerListener.php
+++ b/src/EventListener/LoadDataContainerListener.php
@@ -9,6 +9,9 @@
 namespace HeimrichHannot\CategoriesBundle\EventListener;
 
 use HeimrichHannot\CategoriesBundle\Backend\Category;
+use HeimrichHannot\CategoriesBundle\Filter\Type\CategoryChoiceType;
+use HeimrichHannot\CategoriesBundle\Filter\Type\ParentCategoryChoiceType;
+use HeimrichHannot\FilterBundle\Filter\Type\ChoiceType;
 
 /**
  * @Hook("loadDataContainer")
@@ -30,12 +33,12 @@ class LoadDataContainerListener
         }
         $dca = &$GLOBALS['TL_DCA']['tl_filter_config_element'];
 
-        $dca['palettes'][\HeimrichHannot\CategoriesBundle\Filter\Type\CategoryChoiceType::TYPE] = str_replace(
+        $dca['palettes'][CategoryChoiceType::TYPE] = str_replace(
             'field,',
             'field,parentCategories,',
-            $dca['palettes'][\HeimrichHannot\FilterBundle\Filter\Type\ChoiceType::TYPE]
+            $dca['palettes'][ChoiceType::TYPE]
         );
-        $dca['palettes'][\HeimrichHannot\CategoriesBundle\Filter\Type\ParentCategoryChoiceType::TYPE] =
+        $dca['palettes'][ParentCategoryChoiceType::TYPE] =
             '{general_legend},title,type;
             {config_legend},field,parentCategories;
             {publish_legend},published;';

--- a/src/Filter/Type/ParentCategoryChoiceType.php
+++ b/src/Filter/Type/ParentCategoryChoiceType.php
@@ -24,9 +24,9 @@ class ParentCategoryChoiceType extends AbstractType
 
     public function buildQuery(FilterQueryBuilder $builder, FilterConfigElementModel $element)
     {
-        $parentCategorieIds = StringUtil::deserialize($element->parentCategories, true);
+        $parentCategoryIds = StringUtil::deserialize($element->parentCategories, true);
         /** @var CategoryModel[]|Collection|null $parentCategories */
-        $parentCategories = System::getContainer()->get('huh.utils.model')->findMultipleModelInstancesByIds('tl_category', $parentCategorieIds);
+        $parentCategories = System::getContainer()->get('huh.utils.model')->findMultipleModelInstancesByIds('tl_category', $parentCategoryIds);
 
         if (!$parentCategories) {
             return;


### PR DESCRIPTION
- added parent category filter type
- added CategoryModel::getChildCategories()
- added CategoryModel::hasChildCategories()
- added CategoryModel::getDescendantCategories()
- added CategoryModel annotation
- moved filter config element dca config to loadDataContainer hook
- update some imports in CategoryManager