### PR TITLE
[Fix]: Sorting categories menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [1.1.1-DEV] - 2020-12-11
+## [1.1.1] - 2020-12-11
+- fixed sorting in CategoriesMenu module
+- fixed calling urls with Umlaut
 - Fix missing field and palette problem in contao 4.9 (#9)
 
 ## [1.1.0] - 2020-12-01

--- a/src/Manager/CategoryManager.php
+++ b/src/Manager/CategoryManager.php
@@ -460,7 +460,7 @@ class CategoryManager
             return null;
         }
 
-        return \Model\Collection::createFromDbResult($objCategories, 'tl_category');  
+        return \Model\Collection::createFromDbResult($objCategories, 'tl_category');
     }
 
     /**

--- a/src/Manager/CategoryManager.php
+++ b/src/Manager/CategoryManager.php
@@ -454,13 +454,13 @@ class CategoryManager
             return null;
         }
 
-        $objCategories = \Database::getInstance()->prepare('SELECT c1.*, (SELECT COUNT(*) FROM tl_category  c2 WHERE c2.pid=c1.id AND c2.id IN ('.implode(',', array_map('intval', $arrIds)).')) AS subcategories FROM tl_category c1 WHERE c1.pid=? AND c1.id IN ('.implode(',', array_map('intval', $arrIds)).')')->execute($pid);
+        $objCategories = \Database::getInstance()->prepare('SELECT c1.*, (SELECT COUNT(*) FROM tl_category  c2 WHERE c2.pid=c1.id AND c2.id IN ('.implode(',', array_map('intval', $arrIds)).')) AS subcategories FROM tl_category c1 WHERE c1.pid=? AND c1.id IN ('.implode(',', array_map('intval', $arrIds)).') ORDER BY sorting ASC')->execute($pid);
 
         if ($objCategories->numRows < 1) {
             return null;
         }
 
-        return \Model\Collection::createFromDbResult($objCategories, 'tl_category');
+        return \Model\Collection::createFromDbResult($objCategories, 'tl_category');  
     }
 
     /**

--- a/src/Module/ModuleCategoriesMenu.php
+++ b/src/Module/ModuleCategoriesMenu.php
@@ -159,7 +159,7 @@ class ModuleCategoriesMenu extends \Contao\Module
         }
 
         $objTemplate = new FrontendTemplate($this->navigationTpl);
-        $objTemplate->type = \get_class($this);
+        $objTemplate->type = static::class;
         $objTemplate->cssID = $this->cssID;
         $objTemplate->level = 'level_'.$intLevel;
         $objTemplate->showQuantity = $this->cm_showQuantity;

--- a/src/Module/ModuleCategoriesMenu.php
+++ b/src/Module/ModuleCategoriesMenu.php
@@ -214,7 +214,7 @@ class ModuleCategoriesMenu extends \Contao\Module
             $arrRow['title'] = StringUtil::specialchars($strTitle, true);
             $arrRow['linkTitle'] = StringUtil::specialchars($strTitle, true);
             $arrRow['link'] = $strTitle;
-            $arrRow['href'] = ampersand(sprintf($strUrl, ($GLOBALS['TL_CONFIG']['disableAlias'] ? $category->id : $category->alias)));
+            $arrRow['href'] = ampersand(str_replace('%s', ($GLOBALS['TL_CONFIG']['disableAlias'] ? $category->id : $category->alias), $strUrl));
 
             $arrCategories[] = $arrRow;
         }


### PR DESCRIPTION
Der PR bezieht sich auf https://github.com/heimrichhannot/contao-categories-bundle/issues/7

Testschritte:
- contao-categories-bundle mit in contao projekt per composer einbinden
- Zu 'Kategorien' unter 'Inhalte' wechseln
- Neue Kategorien anlegen
- Neues Frontend Modul unter Layout/Themes mit Modultypen 'categoriesMenu' anlegen -> 'Start-Kategorie' einchecken und Kategorie auswählen
- Dieses Modul in Artikel einsetzen
- Website aufrufen